### PR TITLE
Fix minor errors

### DIFF
--- a/Modules/Introduction to Spark - Student Lab.ipynb
+++ b/Modules/Introduction to Spark - Student Lab.ipynb
@@ -880,7 +880,7 @@
     "      </h4>\n",
     "    </div>\n",
     "    <div id=\"collapse3-33\" class=\"panel-collapse collapse\">\n",
-    "      <div class=\"panel-body\">There are 19 lines which contain the word \"Spark\".   Find all lines which contain it when case-insensitive<br></div>\n",
+    "      <div class=\"panel-body\">There are 28 lines which contain the word \"Spark\".   Find all lines which contain it when case-insensitive<br></div>\n",
     "    </div>\n",
     "  </div>\n",
     "</div> "

--- a/Modules/Introduction to Spark SQL - Student Lab.ipynb
+++ b/Modules/Introduction to Spark SQL - Student Lab.ipynb
@@ -293,7 +293,7 @@
     "      </h4>\n",
     "    </div>\n",
     "    <div id=\"collapse3-32\" class=\"panel-collapse collapse\">\n",
-    "      <div class=\"panel-body\">Save the table as a parquet table.   Use !ls to confirm it was saved.  Use a <i><a href=\"https://spark.apache.org/docs/1.6.2/api/python/pyspark.sql.html#pyspark.sql.DataFrameWriter\"DataFrameWriter></a></i>  What did you see when you ran the ls command?</div>\n",
+    "      <div class=\"panel-body\">Save the table as a parquet table.   Use !ls to confirm it was saved.  Use a <i><a href=\"https://spark.apache.org/docs/1.6.2/api/python/pyspark.sql.html#pyspark.sql.DataFrameWriter\">DataFrameWriter</a></i>.  What did you see when you ran the ls command?</div>\n",
     "    </div>\n",
     "  </div>\n",
     "</div> \n",


### PR DESCRIPTION
1.  It looks like there are 28 lines, not 19 lines, that contain "spark" in the Spark README.md now.
1.  Link formatting fix.